### PR TITLE
Fix positioning of category scroll buttons

### DIFF
--- a/RiskOfOptions/Components/RuntimePrefabs/ModOptionsPanelPrefab.cs
+++ b/RiskOfOptions/Components/RuntimePrefabs/ModOptionsPanelPrefab.cs
@@ -343,11 +343,14 @@ namespace RiskOfOptions.Components.RuntimePrefabs
             CategoryLeftButton = Object.Instantiate(_emptyButton, scrollView.transform);
             Object.DestroyImmediate(CategoryLeftButton.GetComponent<LayoutElement>());
 
-            const float categoryScrollButtonAnchoredPositionY = -60; // -54 for main menu; -60 for pause menu??
+            Vector2 anchorMiddleLeft = new Vector2(0, 0.5f);
+            Vector2 anchorMiddleRight = new Vector2(1, 0.5f);
+
             var leftButtonRectTransform = CategoryLeftButton.GetComponent<RectTransform>();
+            leftButtonRectTransform.anchorMin = anchorMiddleLeft;
+            leftButtonRectTransform.anchorMax = anchorMiddleLeft;
             leftButtonRectTransform.sizeDelta = new Vector2(64, 64);
-            leftButtonRectTransform.anchoredPosition = new Vector2(60, categoryScrollButtonAnchoredPositionY);
-            // leftButtonRectTransform.localPosition = new Vector2(-522, categoryScrollButtonAnchoredPositionY); // values obtained using UnityExplorer; but setting local position via code seems to get overwritten — maybe because of pivot/anchor?
+            leftButtonRectTransform.anchoredPosition = Vector2.right * 60;
 
             CategoryLeftButton.GetComponentInChildren<LanguageTextMeshController>().token = LanguageTokens.LeftPageButton;
 
@@ -360,7 +363,10 @@ namespace RiskOfOptions.Components.RuntimePrefabs
             
             CategoryRightButton = Object.Instantiate(CategoryLeftButton, scrollView.transform);
 
-            CategoryRightButton.GetComponent<RectTransform>().anchoredPosition = new Vector2(1105, categoryScrollButtonAnchoredPositionY);
+            var rightButtonRectTransform = CategoryRightButton.GetComponent<RectTransform>();
+            rightButtonRectTransform.anchorMin = anchorMiddleRight;
+            rightButtonRectTransform.anchorMax = anchorMiddleRight;
+            rightButtonRectTransform.anchoredPosition *= new Vector2(-1, 1); // Invert x
 
             CategoryRightButton.GetComponentInChildren<LanguageTextMeshController>().token = LanguageTokens.RightPageButton;
 

--- a/RiskOfOptions/Components/RuntimePrefabs/ModOptionsPanelPrefab.cs
+++ b/RiskOfOptions/Components/RuntimePrefabs/ModOptionsPanelPrefab.cs
@@ -343,10 +343,11 @@ namespace RiskOfOptions.Components.RuntimePrefabs
             CategoryLeftButton = Object.Instantiate(_emptyButton, scrollView.transform);
             Object.DestroyImmediate(CategoryLeftButton.GetComponent<LayoutElement>());
 
-            float scrollButtonAnchoredPositionY = RiskOfOptionsPlugin.categoryScrollButtonAnchoredPositionY?.Value ?? -60;
+            const float categoryScrollButtonAnchoredPositionY = -60; // -54 for main menu; -60 for pause menu??
             var leftButtonRectTransform = CategoryLeftButton.GetComponent<RectTransform>();
             leftButtonRectTransform.sizeDelta = new Vector2(64, 64);
-            leftButtonRectTransform.anchoredPosition = new Vector2(60, scrollButtonAnchoredPositionY);
+            leftButtonRectTransform.anchoredPosition = new Vector2(60, categoryScrollButtonAnchoredPositionY);
+            // leftButtonRectTransform.localPosition = new Vector2(-522, categoryScrollButtonAnchoredPositionY); // values obtained using UnityExplorer; but setting local position via code seems to get overwritten — maybe because of pivot/anchor?
 
             CategoryLeftButton.GetComponentInChildren<LanguageTextMeshController>().token = LanguageTokens.LeftPageButton;
 
@@ -359,8 +360,8 @@ namespace RiskOfOptions.Components.RuntimePrefabs
             
             CategoryRightButton = Object.Instantiate(CategoryLeftButton, scrollView.transform);
 
-            CategoryRightButton.GetComponent<RectTransform>().anchoredPosition = new Vector2(1064, scrollButtonAnchoredPositionY);
-             
+            CategoryRightButton.GetComponent<RectTransform>().anchoredPosition = new Vector2(1105, categoryScrollButtonAnchoredPositionY);
+
             CategoryRightButton.GetComponentInChildren<LanguageTextMeshController>().token = LanguageTokens.RightPageButton;
 
             CategoryLeftButton.name = "Previous Category Page Button";

--- a/RiskOfOptions/Components/RuntimePrefabs/ModOptionsPanelPrefab.cs
+++ b/RiskOfOptions/Components/RuntimePrefabs/ModOptionsPanelPrefab.cs
@@ -343,9 +343,10 @@ namespace RiskOfOptions.Components.RuntimePrefabs
             CategoryLeftButton = Object.Instantiate(_emptyButton, scrollView.transform);
             Object.DestroyImmediate(CategoryLeftButton.GetComponent<LayoutElement>());
 
+            float scrollButtonAnchoredPositionY = RiskOfOptionsPlugin.categoryScrollButtonAnchoredPositionY?.Value ?? -60;
             var leftButtonRectTransform = CategoryLeftButton.GetComponent<RectTransform>();
             leftButtonRectTransform.sizeDelta = new Vector2(64, 64);
-            leftButtonRectTransform.anchoredPosition = new Vector2(60, 54);
+            leftButtonRectTransform.anchoredPosition = new Vector2(60, scrollButtonAnchoredPositionY);
 
             CategoryLeftButton.GetComponentInChildren<LanguageTextMeshController>().token = LanguageTokens.LeftPageButton;
 
@@ -358,7 +359,7 @@ namespace RiskOfOptions.Components.RuntimePrefabs
             
             CategoryRightButton = Object.Instantiate(CategoryLeftButton, scrollView.transform);
 
-            CategoryRightButton.GetComponent<RectTransform>().anchoredPosition = new Vector2(1064, 54);
+            CategoryRightButton.GetComponent<RectTransform>().anchoredPosition = new Vector2(1064, scrollButtonAnchoredPositionY);
              
             CategoryRightButton.GetComponentInChildren<LanguageTextMeshController>().token = LanguageTokens.RightPageButton;
 

--- a/RiskOfOptions/RiskOfOptionsPlugin.cs
+++ b/RiskOfOptions/RiskOfOptionsPlugin.cs
@@ -20,8 +20,6 @@ public sealed class RiskOfOptionsPlugin : BaseUnityPlugin
 
     public static ConfigEntry<DecimalSeparator>? decimalSeparator;
 
-    internal static ConfigEntry<float>? categoryScrollButtonAnchoredPositionY;
-
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Code Quality", "IDE0051:Remove unused private members", Justification = "Awake is automatically called by Unity")]
     private void Awake()
     {
@@ -29,8 +27,6 @@ public sealed class RiskOfOptionsPlugin : BaseUnityPlugin
         seenMods = Config.Bind("One Time Stuff", "Has seen the mods prompt", false);
         
         decimalSeparator = Config.Bind("Display", "DecimalSeparator", DecimalSeparator.Period, "Changes how numbers are displayed across RoO.\nPeriod: 1,000.00\nComma: 1.000,00");
-
-        categoryScrollButtonAnchoredPositionY = Config.Bind("Layout (Debug)", nameof(categoryScrollButtonAnchoredPositionY), -60f, "");
 
         ModSettingsManager.Init();
         

--- a/RiskOfOptions/RiskOfOptionsPlugin.cs
+++ b/RiskOfOptions/RiskOfOptionsPlugin.cs
@@ -20,6 +20,8 @@ public sealed class RiskOfOptionsPlugin : BaseUnityPlugin
 
     public static ConfigEntry<DecimalSeparator>? decimalSeparator;
 
+    internal static ConfigEntry<float>? categoryScrollButtonAnchoredPositionY;
+
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Code Quality", "IDE0051:Remove unused private members", Justification = "Awake is automatically called by Unity")]
     private void Awake()
     {
@@ -27,7 +29,9 @@ public sealed class RiskOfOptionsPlugin : BaseUnityPlugin
         seenMods = Config.Bind("One Time Stuff", "Has seen the mods prompt", false);
         
         decimalSeparator = Config.Bind("Display", "DecimalSeparator", DecimalSeparator.Period, "Changes how numbers are displayed across RoO.\nPeriod: 1,000.00\nComma: 1.000,00");
-        
+
+        categoryScrollButtonAnchoredPositionY = Config.Bind("Layout (Debug)", nameof(categoryScrollButtonAnchoredPositionY), -60f, "");
+
         ModSettingsManager.Init();
         
         ModSettingsManager.SetModIcon(Prefabs.animatedIcon);


### PR DESCRIPTION
Hey, just a visual positioning/layout change.

I noticed that the category previous/next buttons appeared vertically offset from the category buttons when accessing the Risk Of Options menu from the pause menu (in contrast to accessing from the main menu).

To try fix this, I've set the anchor positions for the category previous/next buttons so that modifying `anchoredPosition` is more intuitive *(relative to parent, no more need for additional vertical offset)* and yields consistent results *(i.e. consistent between main menu and pause menu)*. This also lets us simply invert the x-position for the right button rather than having to use a (second) magic number.

I've attached an image to demonstrate the change. The top row is from v2.8.2, the bottom row is the proposed change. The left column is from accessing the mod options tab from the main menu, the right column is from accessing the mod options tab from the pause menu (in the lobby).
![riskofoptions-positioning-before-after](https://github.com/user-attachments/assets/521f0eb1-2733-4564-8ff3-dcdb364cae3e)