### PR TITLE
Custom localization for options

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# Ensure commits use UTF-8 encoding
+*.cs text working-tree-encoding=UTF-8
+*.csproj text working-tree-encoding=UTF-8
+*.sln text working-tree-encoding=UTF-8

--- a/RiskOfOptions/Components/Options/ModSettingsControl.cs
+++ b/RiskOfOptions/Components/Options/ModSettingsControl.cs
@@ -4,7 +4,7 @@ using RoR2.UI;
 
 namespace RiskOfOptions.Components.Options;
 
-public abstract class ModSettingsControl<TValue> : ModSettingsControl<TValue, BaseOptionConfig>{}
+public abstract class ModSettingsControl<TValue> : ModSettingsControl<TValue, BaseOptionConfig>;
 
 public abstract class ModSettingsControl<TValue, TOptionConfig> : ModSetting
     where TOptionConfig : BaseOptionConfig

--- a/RiskOfOptions/Components/Panel/ModOptionPanelController.cs
+++ b/RiskOfOptions/Components/Panel/ModOptionPanelController.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -49,7 +49,7 @@ namespace RiskOfOptions.Components.Panel
         private IEnumerator _animateRoutine;
         
         private ModOptionsPanelPrefab _panel;
-        private ModSetting[] _modSettings = Array.Empty<ModSetting>();
+        private ModSetting[] _modSettings = [];
 
         private void Awake()
         {

--- a/RiskOfOptions/Options/BaseOption.cs
+++ b/RiskOfOptions/Options/BaseOption.cs
@@ -62,13 +62,15 @@ namespace RiskOfOptions.Options
         
         public string GetNameToken()
         {
-            if (!string.IsNullOrEmpty(NameToken)) return NameToken;
+            if (!string.IsNullOrEmpty(NameToken))
+                return NameToken;
             return $"{ModSettingsManager.StartingText}.{ModGuid}.{Category}.{Name}.{OptionTypeName}.name".Replace(" ", "_").ToUpper();
         }
 
         public string GetDescriptionToken()
         {
-            if (!string.IsNullOrEmpty(DescriptionToken)) return DescriptionToken;
+            if (!string.IsNullOrEmpty(DescriptionToken))
+                return DescriptionToken;
             return $"{ModSettingsManager.StartingText}.{ModGuid}.{Category}.{Name}.{OptionTypeName}.description".Replace(" ", "_").ToUpper();
         }
         


### PR DESCRIPTION
Hello! While integrating Risk of Options for my mod, I intended to translate all my options, but encountered that I can't easily do that with Risk of Options. Additionally, #41 is still a thing.

I created an override for https://github.com/Rune580/RiskOfOptions/blob/da08aeeb7bb7e7334be1a92635d8878d942934e3/RiskOfOptions/ModSettingsManager.cs#L119
to include a version, which takes two additional `string`s - a name token and a description token.

The `BaseOption` now contains two additional fields. 
```cs
public string DescriptionToken { get; internal set; }
public string NameToken { get; internal set; }
```
These are now included within `GetNameToken` and `GetDescriptionToken`. If a custom translation is present, its token is returned, otherwise, the logic defaults to the existing implementation.

These are used in two new methods - `GetLocalizedName` and `GetLocalizedDescription`. These return the finalized name/description. They either return the custom translated value, or the default config value, if no translation is present.
As mentioned before, #41 was fixed along with these additions.

While I did test the mod, I might have missed some edge-cases. I tried the new overload within my mod and I have received translation. I also used "the old way" of translating - using the generated identifier and I was able to get both the name and the description working. If either a name or description tokens are not provided, the strings default to the config values.

Please, let me know what you think! If you like the idea, I believe I could also implement a way of adding a translation for each of the category names.
