### PR TITLE
Category localization + dropdown menu fix

### DIFF
--- a/RiskOfOptions/Containers/Category.cs
+++ b/RiskOfOptions/Containers/Category.cs
@@ -12,13 +12,25 @@ namespace RiskOfOptions.Containers
         
         public string ModGuid { get; }
         
-        internal string NameToken => $"{ModSettingsManager.StartingText}.{ModGuid}.category.{name}".Replace(" ", "_").ToUpper();
+        internal string NameToken
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(_customNameToken))
+                    return _customNameToken;
+                return $"{ModSettingsManager.StartingText}.{ModGuid}.category.{name}".Replace(" ", "_").ToUpper();
+            }
+        }
+
         internal int OptionCount => _options.Count;
+        
+        private string _customNameToken;
         
         internal Category(string name, string modGuid)
         {
             this.name = name;
             ModGuid = modGuid;
+            _customNameToken = string.Empty;
             
             LanguageApi.Add(NameToken, name);
         }
@@ -64,6 +76,16 @@ namespace RiskOfOptions.Containers
         public static bool operator !=(Category left, Category right)
         {
             return !(left == right);
+        }
+        
+        /// <summary>
+        /// Sets a custom name token for the category.
+        /// Pass in an empty string to remove the custom token (returns to default token).
+        /// </summary>
+        /// <param name="nameToken">Token to set</param>
+        public void SetNameToken(string nameToken)
+        {
+            _customNameToken = nameToken;
         }
     }
 }

--- a/RiskOfOptions/ModSettingsManager.cs
+++ b/RiskOfOptions/ModSettingsManager.cs
@@ -161,5 +161,12 @@ namespace RiskOfOptions
             if (!OptionCollection.ContainsModGuid(modGuid))
                 OptionCollection[modGuid] = new OptionCollection(modName, modGuid);
         }
+
+        public static void SetCategoryNameToken(string modGuid, BaseOption option, string nameToken)
+        {
+            // We send in an option to get the category from it, as that is a good way to make sure the user doesn't
+            // send in a string that does not exist.
+            OptionCollection[modGuid][option.Category].SetNameToken(nameToken);
+        }
     }
 }

--- a/RiskOfOptions/ModSettingsManager.cs
+++ b/RiskOfOptions/ModSettingsManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using MonoMod.RuntimeDetour;
@@ -147,6 +147,11 @@ namespace RiskOfOptions
             option.NameToken = nameToken;
             option.DescriptionToken = descriptionToken;
             option.Identifier = $"{modGuid}.{option.Category}.{option.Name}.{option.OptionTypeName}".Replace(" ", "_").ToUpper();
+
+            if (option is ChoiceOption choiceOption)
+            {
+                choiceOption.RegisterChoiceTokens();
+            }
 
             OptionCollection.AddOption(ref option);
         }

--- a/RiskOfOptions/Options/ChoiceOption.cs
+++ b/RiskOfOptions/Options/ChoiceOption.cs
@@ -41,7 +41,7 @@ namespace RiskOfOptions.Options
             RegisterChoiceTokens();
         }
 
-        public void RegisterChoiceTokens()
+        internal void RegisterChoiceTokens()
         {
             string[] names = Enum.GetNames(Value.GetType());
 

--- a/RiskOfOptions/Options/ChoiceOption.cs
+++ b/RiskOfOptions/Options/ChoiceOption.cs
@@ -38,7 +38,11 @@ namespace RiskOfOptions.Options
         internal override void RegisterTokens()
         {
             base.RegisterTokens();
+            RegisterChoiceTokens();
+        }
 
+        public void RegisterChoiceTokens()
+        {
             string[] names = Enum.GetNames(Value.GetType());
 
             _nameTokens = new string[names.Length];


### PR DESCRIPTION
With my previous addition of localized `BaseOption`, I have introduced a bug that affected all `ChoiceOption`s that used the new localized method. This bug caused a `NullReferenceException` and no selection was displayed in the dropdown. This pull request aims to fix that issue.

Additionally, I have implemented `ModSettingsManager.SetCategoryNameToken`, which allows a modder to provide a custom translation to a category. 

Example usage:
```cs
bool restartRequired = false;
ConfigEntry<int> configEntry = configFile.Bind("My Category", "MyNumber", 0, "This number is very important.");

BaseOption option = new IntFieldOption(configEntry, restartRequired);
// Other versions of AddOption can also be used
ModSettingsManager.AddOption(option, MyMod.GUID, MyMod.Name, "MY_MOD.MY_NUMBER", "MY_MOD.MY_NUMBER_DESCRIPTION");

ModSettingsManager.SetCategoryNameToken(MyMod.GUID, option, "MY_MOD.MY_CATEGORY_NAME");
```

If the method is not used, the old naming is used, ensuring compatibility with previous versions.