### PR TITLE
Various issue fixes + new modified indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ An API to provide a user interface in game to interact with BepInEx ConfigEntry'
 - Sliders `float`
 - StepSliders `float`
 - IntSliders `int`
+- FloatFields `float`
+- IntFields `int`
 - KeyBinds `KeyboardShortcut`
 - String Input Fields `string`
 - Choice DropDowns `Enum`
@@ -83,7 +85,7 @@ And that's it, said KeyboardShortcut will show up on the ModOptions menu.
 Checkbox and Slider configs can be set with a delegate that will be used to check if said option should be disabled in the menu.
 ```C#
 ConfigEntry<bool> disableThing = Config.Bind(...);
-ConfigEntry<bool> overridenThing = Config.Bind(...); 
+ConfigEntry<bool> overridenThing = Config.Bind(...);
 
 ModSettingsManager.AddOption(new CheckBoxOption(disableThing));
 ModSettingsManager.AddOption(new CheckBoxOption(overridenThing, new CheckBoxConfig() { checkIfDisabled = Check }));

--- a/RiskOfOptions/Components/Options/ModSetting.cs
+++ b/RiskOfOptions/Components/Options/ModSetting.cs
@@ -38,6 +38,8 @@ namespace RiskOfOptions.Components.Options
         public abstract void Revert();
 
         public abstract void CheckIfDisabled();
+
+        public virtual void UpdateModifiedIndicator() { }
         
         protected abstract void Disable();
 

--- a/RiskOfOptions/Components/Options/ModSettingsControl.cs
+++ b/RiskOfOptions/Components/Options/ModSettingsControl.cs
@@ -46,6 +46,20 @@ public abstract class ModSettingsControl<TValue, TOptionConfig> : ModSetting
         return valueHolder.Value;
     }
 
+    protected TValue GetDefaultValue()
+    {
+        //! This does breaks on mods that use ZioRiskOfOptions
+        if (option.ConfigEntry == null)
+        {
+#if DEBUG
+            UnityEngine.Debug.LogWarning($"{nameof(RiskOfOptions)}: Could not get default value, mod uses ZioRiskOfOptions?");
+#endif
+            return GetCurrentValue();
+        }
+
+        return (TValue)option.ConfigEntry.DefaultValue;
+    }
+
     public override bool HasChanged()
     {
         return _valueChanged;
@@ -69,7 +83,7 @@ public abstract class ModSettingsControl<TValue, TOptionConfig> : ModSetting
         if (option is null)
             return;
 
-        SubmitValue((TValue)option.ConfigEntry.DefaultValue);
+        SubmitValue(GetDefaultValue());
     }
 
     protected override void Awake()
@@ -161,8 +175,9 @@ public abstract class ModSettingsControl<TValue, TOptionConfig> : ModSetting
         CheckIfDisabled();
         RestartRequiredCheck();
 
-        if (modifiedIndicator) {
-            bool nonDefault = !GetCurrentValue().Equals((TValue)option.ConfigEntry.DefaultValue);
+        if (modifiedIndicator)
+        {
+            bool nonDefault = !GetCurrentValue().Equals(GetDefaultValue());
             modifiedIndicator.enabled = nonDefault || HasChanged();
             modifiedIndicator.color = HasChanged() ? hasChangedColor : nonDefaultColor;
         }

--- a/RiskOfOptions/Components/Options/ModSettingsControl.cs
+++ b/RiskOfOptions/Components/Options/ModSettingsControl.cs
@@ -22,6 +22,8 @@ public abstract class ModSettingsControl<TValue, TOptionConfig> : ModSetting
     protected ITypedValueHolder<TValue> valueHolder;
 
     private UnityEngine.UI.RawImage modifiedIndicator;
+    private readonly UnityEngine.Color nonDefaultColor = new UnityEngine.Color(122f/255, 176f/255, 255f/255);
+    private readonly UnityEngine.Color hasChangedColor = new UnityEngine.Color(255f/255, 230f/255, 73f/255);
 
     public void SubmitValue(TValue newValue)
     {
@@ -159,8 +161,11 @@ public abstract class ModSettingsControl<TValue, TOptionConfig> : ModSetting
         CheckIfDisabled();
         RestartRequiredCheck();
 
-        if (modifiedIndicator)
-            modifiedIndicator.enabled = (!GetCurrentValue().Equals((TValue)option.ConfigEntry.DefaultValue));
+        if (modifiedIndicator) {
+            bool nonDefault = !GetCurrentValue().Equals((TValue)option.ConfigEntry.DefaultValue);
+            modifiedIndicator.enabled = nonDefault || HasChanged();
+            modifiedIndicator.color = HasChanged() ? hasChangedColor : nonDefaultColor;
+        }
 
         InUpdateControls = true;
         OnUpdateControls();
@@ -182,6 +187,6 @@ public abstract class ModSettingsControl<TValue, TOptionConfig> : ModSetting
         childTransform.sizeDelta = UnityEngine.Vector2.zero;
 
         modifiedIndicator = child.GetComponent<UnityEngine.UI.RawImage>();
-        modifiedIndicator.color = new UnityEngine.Color(122f/255, 176f/255, 255f/255);
+        modifiedIndicator.color = nonDefaultColor;
     }
 }

--- a/RiskOfOptions/Components/Options/ModSettingsControl.cs
+++ b/RiskOfOptions/Components/Options/ModSettingsControl.cs
@@ -20,7 +20,8 @@ public abstract class ModSettingsControl<TValue, TOptionConfig> : ModSetting
     protected TOptionConfig? Config { get; private set; }
         
     protected ITypedValueHolder<TValue> valueHolder;
-    
+
+    private UnityEngine.UI.RawImage modifiedIndicator;
 
     public void SubmitValue(TValue newValue)
     {
@@ -81,6 +82,8 @@ public abstract class ModSettingsControl<TValue, TOptionConfig> : ModSetting
         valueHolder ??= (ITypedValueHolder<TValue>)option;
 
         Config = (TOptionConfig)option.GetConfig();
+
+        CreateModifiedIndicator();
 
         _restartRequired = Config.restartRequired;
             
@@ -156,10 +159,29 @@ public abstract class ModSettingsControl<TValue, TOptionConfig> : ModSetting
         CheckIfDisabled();
         RestartRequiredCheck();
 
+        if (modifiedIndicator)
+            modifiedIndicator.enabled = (!GetCurrentValue().Equals((TValue)option.ConfigEntry.DefaultValue));
+
         InUpdateControls = true;
         OnUpdateControls();
         InUpdateControls = false;
     }
         
     protected virtual void OnUpdateControls() {}
+
+    private void CreateModifiedIndicator()
+    {
+        UnityEngine.GameObject child = new UnityEngine.GameObject("Modified Indicator", typeof(UnityEngine.UI.RawImage));
+        UnityEngine.RectTransform childTransform = (UnityEngine.RectTransform)child.transform;
+        childTransform.SetParent(this.transform);
+        childTransform.SetAsFirstSibling(); // to move to bottom layer, visually
+        childTransform.pivot = new UnityEngine.Vector2(0, 0.5f);
+        childTransform.anchoredPosition = UnityEngine.Vector2.zero;
+        childTransform.anchorMax = new UnityEngine.Vector2(0.016f, 0.92f);
+        childTransform.anchorMin = new UnityEngine.Vector2(0.009f, 0.08f);
+        childTransform.sizeDelta = UnityEngine.Vector2.zero;
+
+        modifiedIndicator = child.GetComponent<UnityEngine.UI.RawImage>();
+        modifiedIndicator.color = new UnityEngine.Color(122f/255, 176f/255, 255f/255);
+    }
 }

--- a/RiskOfOptions/Components/Options/ModSettingsControl.cs
+++ b/RiskOfOptions/Components/Options/ModSettingsControl.cs
@@ -21,9 +21,7 @@ public abstract class ModSettingsControl<TValue, TOptionConfig> : ModSetting
         
     protected ITypedValueHolder<TValue> valueHolder;
 
-    private UnityEngine.UI.RawImage modifiedIndicator;
-    private readonly UnityEngine.Color nonDefaultColor = new UnityEngine.Color(122f/255, 176f/255, 255f/255);
-    private readonly UnityEngine.Color hasChangedColor = new UnityEngine.Color(255f/255, 230f/255, 73f/255);
+    private UnityEngine.UI.RawImage? modifiedIndicator;
 
     public void SubmitValue(TValue newValue)
     {
@@ -48,7 +46,7 @@ public abstract class ModSettingsControl<TValue, TOptionConfig> : ModSetting
 
     protected TValue GetDefaultValue()
     {
-        //! This does breaks on mods that use ZioRiskOfOptions
+        // ConfigEntry is null on mods that use ZioRiskOfOptions (see https://github.com/Rune580/RiskOfOptions/pull/28 )
         if (option.ConfigEntry == null)
         {
 #if DEBUG
@@ -159,6 +157,16 @@ public abstract class ModSettingsControl<TValue, TOptionConfig> : ModSetting
         }
     }
 
+    public override void UpdateModifiedIndicator()
+    {
+        if (modifiedIndicator)
+        {
+            bool nonDefault = !GetCurrentValue().Equals(GetDefaultValue());
+            modifiedIndicator.enabled = (nonDefault || HasChanged()) && RiskOfOptionsPlugin.showModifiedIndicator!.Value;
+            modifiedIndicator.color = HasChanged() ? RiskOfOptionsPlugin.hasChangedModifiedColor!.Value : RiskOfOptionsPlugin.nonDefaultModifiedColor!.Value;
+        }
+    }
+
     protected bool InUpdateControls { get; private set; }
 
     protected void UpdateControls()
@@ -174,13 +182,7 @@ public abstract class ModSettingsControl<TValue, TOptionConfig> : ModSetting
 
         CheckIfDisabled();
         RestartRequiredCheck();
-
-        if (modifiedIndicator)
-        {
-            bool nonDefault = !GetCurrentValue().Equals(GetDefaultValue());
-            modifiedIndicator.enabled = nonDefault || HasChanged();
-            modifiedIndicator.color = HasChanged() ? hasChangedColor : nonDefaultColor;
-        }
+        UpdateModifiedIndicator();
 
         InUpdateControls = true;
         OnUpdateControls();
@@ -202,6 +204,7 @@ public abstract class ModSettingsControl<TValue, TOptionConfig> : ModSetting
         childTransform.sizeDelta = UnityEngine.Vector2.zero;
 
         modifiedIndicator = child.GetComponent<UnityEngine.UI.RawImage>();
-        modifiedIndicator.color = nonDefaultColor;
+        modifiedIndicator.color = RiskOfOptionsPlugin.nonDefaultModifiedColor!.Value;
+        modifiedIndicator.enabled = RiskOfOptionsPlugin.showModifiedIndicator!.Value;
     }
 }

--- a/RiskOfOptions/Components/Options/ModSettingsStepSlider.cs
+++ b/RiskOfOptions/Components/Options/ModSettingsStepSlider.cs
@@ -17,6 +17,7 @@ public class ModSettingsStepSlider : ModSettingsControl<float, StepSliderConfig>
     public float minValue;
     public float maxValue;
     public float increment;
+    public bool remapManualInputToStep;
     public string formatString;
         
     private SliderConfig.SliderTryParse? _tryParse;
@@ -86,9 +87,13 @@ public class ModSettingsStepSlider : ModSettingsControl<float, StepSliderConfig>
         {
             num = Mathf.Clamp(num, minValue, maxValue);
 
-            float step = Mathf.Abs(num - minValue) / increment;
+            if (remapManualInputToStep)
+            {
+                float step = Mathf.Abs(num - minValue) / increment;
+                num = Mathf.RoundToInt(step) * increment + minValue;
+            }
 
-            SubmitValue(Mathf.RoundToInt(step) * increment + minValue);
+            SubmitValue(num);
         }
         else
         {

--- a/RiskOfOptions/Components/Panel/ModOptionPanelController.cs
+++ b/RiskOfOptions/Components/Panel/ModOptionPanelController.cs
@@ -683,7 +683,10 @@ namespace RiskOfOptions.Components.Panel
             foreach (var modSetting in _modSettings)
             {
                 if (modSetting)
+                {
                     modSetting.CheckIfDisabled();
+                    modSetting.UpdateModifiedIndicator();
+                }
             }
                 
         }

--- a/RiskOfOptions/Components/RuntimePrefabs/ChoicePrefab.cs
+++ b/RiskOfOptions/Components/RuntimePrefabs/ChoicePrefab.cs
@@ -47,9 +47,18 @@ namespace RiskOfOptions.Components.RuntimePrefabs
              button.targetGraphic = dropDownTargetGraphic;
              button.navigation = new Navigation();
              button.onClick.RemoveAllListeners();
-            
-             ChoiceButton.AddComponent<DropDownController>().nameLabel = ChoiceButton.transform.Find("Text, Name").GetComponent<LanguageTextMeshController>();
-            
+
+             Transform ChoiceButtonLabel = ChoiceButton.transform.Find("Text, Name");
+             ChoiceButton.AddComponent<DropDownController>().nameLabel = ChoiceButtonLabel.GetComponent<LanguageTextMeshController>();
+
+            // todo: fix this in the Unity prefab and update the asset bundle?
+            // values obtained from cross-referencing other option prefabs using Unity Explorer
+            RectTransform fixPosition = (RectTransform)ChoiceButtonLabel;
+            fixPosition.anchoredPosition = Vector2.zero;
+            fixPosition.pivot = new Vector2(0.5f, 0.5f);
+            fixPosition.sizeDelta = new Vector2(-24, -8);
+            fixPosition.anchorMax = new Vector2(0.5f, 1f);
+             
              var dropDownGameObject = ChoiceButton.transform.Find("CarouselRect").Find("ResolutionDropdown").gameObject;
              dropDownGameObject.name = "Dropdown";
             

--- a/RiskOfOptions/OptionConfigs/StepSliderConfig.cs
+++ b/RiskOfOptions/OptionConfigs/StepSliderConfig.cs
@@ -3,6 +3,7 @@
 public class StepSliderConfig : SliderConfig
 {
     public float increment = 1;
+    public bool remapManualInputToStep = true;
 
     public override string FormatString { get; set; } = "{0}";
 }

--- a/RiskOfOptions/Options/StepSliderOption.cs
+++ b/RiskOfOptions/Options/StepSliderOption.cs
@@ -44,6 +44,7 @@ namespace RiskOfOptions.Options
             settingsSlider.increment = config.increment;
             settingsSlider.minValue = config.min;
             settingsSlider.maxValue = config.max;
+            settingsSlider.remapManualInputToStep = config.remapManualInputToStep;
             settingsSlider.formatString = config.FormatString;
             
             double stepsHighAccuracy = Math.Abs(config.min - config.max) / config.increment;

--- a/RiskOfOptions/RiskOfOptionsPlugin.cs
+++ b/RiskOfOptions/RiskOfOptionsPlugin.cs
@@ -2,6 +2,7 @@
 using System.Security.Permissions;
 using BepInEx;
 using BepInEx.Configuration;
+using RiskOfOptions.OptionConfigs;
 using RiskOfOptions.Options;
 using RiskOfOptions.Resources;
 
@@ -19,18 +20,32 @@ public sealed class RiskOfOptionsPlugin : BaseUnityPlugin
     internal static ConfigEntry<bool>? seenMods;
 
     public static ConfigEntry<DecimalSeparator>? decimalSeparator;
+    public static ConfigEntry<bool>? showModifiedIndicator;
+    public static ConfigEntry<UnityEngine.Color>? nonDefaultModifiedColor;
+    public static ConfigEntry<UnityEngine.Color>? hasChangedModifiedColor;
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Code Quality", "IDE0051:Remove unused private members", Justification = "Awake is automatically called by Unity")]
     private void Awake()
     {
-        seenNoMods = Config.Bind("One Time Stuff", "Has seen the no mods prompt", false);
-        seenMods = Config.Bind("One Time Stuff", "Has seen the mods prompt", false);
-        
-        decimalSeparator = Config.Bind("Display", "DecimalSeparator", DecimalSeparator.Period, "Changes how numbers are displayed across RoO.\nPeriod: 1,000.00\nComma: 1.000,00");
+        const string ONE_TIME_STUFF = "One Time Stuff";
+        seenNoMods = Config.Bind(ONE_TIME_STUFF, "Has seen the no mods prompt", false);
+        seenMods = Config.Bind(ONE_TIME_STUFF, "Has seen the mods prompt", false);
+
+        const string DISPLAY = "Display";
+        decimalSeparator = Config.Bind(DISPLAY, "DecimalSeparator", DecimalSeparator.Period, "Changes how numbers are displayed across RoO.\nPeriod: 1,000.00\nComma: 1.000,00");
+        showModifiedIndicator = Config.Bind(DISPLAY, "Show modified indicator", true, "Show a colored marker on the left of mod options that have been modified");
+        nonDefaultModifiedColor = Config.Bind(DISPLAY, "Modified color (non-default)", new UnityEngine.Color(122f/255, 176f/255, 255f/255), "Color of the modified indicator when a mod option has a value different from its default");
+        hasChangedModifiedColor = Config.Bind(DISPLAY, "Modified color (revertable)", new UnityEngine.Color(255f/255, 230f/255, 73f/255), "Color of the modified indicator when a mod option has changed but is still able to be reverted");
 
         ModSettingsManager.Init();
         
         ModSettingsManager.SetModIcon(Prefabs.animatedIcon);
         ModSettingsManager.AddOption(new ChoiceOption(decimalSeparator));
+        ModSettingsManager.AddOption(new CheckBoxOption(showModifiedIndicator));
+        ColorOptionConfig modifiedIndicatorDependent = new ColorOptionConfig { checkIfDisabled = DisabledModifiedIndicator };
+        ModSettingsManager.AddOption(new ColorOption(nonDefaultModifiedColor, modifiedIndicatorDependent));
+        ModSettingsManager.AddOption(new ColorOption(hasChangedModifiedColor, modifiedIndicatorDependent));
     }
+
+    private bool DisabledModifiedIndicator() => !showModifiedIndicator!.Value;
 }

--- a/RiskOfOptions/Test/TestPlugin.cs
+++ b/RiskOfOptions/Test/TestPlugin.cs
@@ -1,0 +1,73 @@
+﻿#if DEBUG
+using BepInEx;
+using BepInEx.Configuration;
+using RiskOfOptions.Options;
+
+namespace RiskOfOptions.Test
+{
+    [BepInDependency(RiskOfOptions.PluginInfo.PLUGIN_GUID)]
+    [BepInPlugin(GUID, NAME, VERSION)]
+    internal sealed class TestPlugin : BaseUnityPlugin
+    {
+        public const string GUID = "com.rune580.riskofoptions.test";
+        public const string NAME = "RiskOfOptions.Test";
+        public const string VERSION = "0.0.0";
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+        public static new Config Config { get; private set; }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+
+        private void Awake()
+        {
+            Config = new Config(base.Config);
+
+            ModSettingsManager.AddOption(new CheckBoxOption(Config.checkBox));
+            ModSettingsManager.AddOption(new SliderOption(Config.slider, new OptionConfigs.SliderConfig { min = -50, max = 50 }));
+            ModSettingsManager.AddOption(new StepSliderOption(Config.stepSlider, new OptionConfigs.StepSliderConfig { min = -50, max = 50, increment = 0.5f }));
+            ModSettingsManager.AddOption(new StepSliderOption(Config.stepSliderFree, new OptionConfigs.StepSliderConfig { min = -50, max = 50, remapManualInputToStep = false, increment = 0.5f }));
+            ModSettingsManager.AddOption(new IntSliderOption(Config.intSlider, new OptionConfigs.IntSliderConfig { min = -50, max = 50 }));
+            ModSettingsManager.AddOption(new FloatFieldOption(Config.floatField));
+            ModSettingsManager.AddOption(new IntFieldOption(Config.intField));
+            ModSettingsManager.AddOption(new KeyBindOption(Config.keyBind));
+            ModSettingsManager.AddOption(new StringInputFieldOption(Config.inputField));
+            ModSettingsManager.AddOption(new ChoiceOption(Config.dropDown));
+            ModSettingsManager.AddOption(new ColorOption(Config.colorPicker));
+        }
+    }
+
+    public sealed class Config
+    {
+        private readonly ConfigFile file;
+
+        internal readonly ConfigEntry<bool> checkBox;
+        internal readonly ConfigEntry<float> slider;
+        internal readonly ConfigEntry<float> stepSlider;
+        internal readonly ConfigEntry<float> stepSliderFree;
+        internal readonly ConfigEntry<int> intSlider;
+        internal readonly ConfigEntry<float> floatField;
+        internal readonly ConfigEntry<int> intField;
+        internal readonly ConfigEntry<KeyboardShortcut> keyBind;
+        internal readonly ConfigEntry<string> inputField;
+        internal readonly ConfigEntry<UnityEngine.KeyCode> dropDown;
+        internal readonly ConfigEntry<UnityEngine.Color> colorPicker;
+
+        internal Config(ConfigFile config)
+        {
+            file = config;
+
+            const string Section = "_";
+            checkBox = config.Bind(Section, nameof(checkBox), false, "");
+            slider = config.Bind(Section, nameof(slider), 1.28f, "");
+            stepSlider = config.Bind(Section, nameof(stepSlider), 1.28f, "Increment = 0.5f");
+            stepSliderFree = config.Bind(Section, nameof(stepSliderFree), 1.28f, "Increment = 0.5f");
+            intSlider = config.Bind(Section, nameof(intSlider), 2, "");
+            floatField = config.Bind(Section, nameof(floatField), 1.28f);
+            intField = config.Bind(Section, nameof(intField), 2);
+            keyBind = config.Bind(Section, nameof(keyBind), KeyboardShortcut.Empty, "");
+            inputField = config.Bind(Section, nameof(inputField), "a", "");
+            dropDown = config.Bind(Section, nameof(dropDown), UnityEngine.KeyCode.Space, "");
+            colorPicker = config.Bind(Section, nameof(colorPicker), UnityEngine.Color.green, "");
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## changes
* Update `README.md` to list FloatFields and IntFields (added in v2.8.0) under "Currently supported options"
* Code-based fix for labels in ChoiceOptions appearing indented (addresses #49)
    * *my personal preference is to implement everything in code, but seeing as this project uses prefabs for UI elements, a better solution may be editing the actual prefab in Unity*

## additions
* Create `TestPlugin.cs` that is only built on Debug configurations for development/testing purposes.
    * *this can be deleted if it doesn't belong, but it won't exist on release builds anyway*
* Add a setting to `StepSliderConfig` to allow text entry of values that are not remapped to the nearest increment (addresses #30)
    * *I've named the setting `remapManualInputToStep`, which I'm <mark>**not sure is the best name**</mark> for this*
    * <mark>**Uncertain what the default value should be**</mark>. Currently uses `true` to match existing behaviour, making this change an opt-in
* Add a "modified" indicator to the side of options that have been modified *(similar to indicator in VS Code settings)*
    <img width="544" height="209" alt="modified-indicator" src="https://github.com/user-attachments/assets/f43c4061-3414-4f33-a3bf-01fc63adb7bb" />
    * Options that have a non-default value show a blue "modified" indicator
    * Options that have been modified and can be reverted using the "Revert" button *(now "Reset to Default" in Alloyed Collective update?)* show a yellow "modified" indicator. This takes precedence over the blue non-default indicator.
    * This is aimed at making it easier to identify which changes will be reverted or are non-default (and is slightly relevant to #27)
    * <mark>**Should there be a config option to disable showing this indicator?**</mark>
    * <mark>**Should the colours be changed/adjusted?**</mark> *(kinda chose them without too much thought)*

## closes
#30, #49
Given that the issue with 2.8.3 appears to have been resolved as [DiscordRichPresence](https://github.com/mikhailmikhalchuk/RoR2-Discord-RP/pull/12) accidentally bundling Risk of Options 2.8.2, a new release should also close the following: #44, #45, #46, #48